### PR TITLE
Better specs navigation button for mobile

### DIFF
--- a/src/components/shared/core/guide/navigation/Navigation.tsx
+++ b/src/components/shared/core/guide/navigation/Navigation.tsx
@@ -59,7 +59,7 @@ function Navigation({ headerRef }: Readonly<Props>) {
           className={`anim bg-primary-2 border-primary-3 pointer-events-auto absolute bottom-0 right-0 z-40 flex w-full max-w-72 flex-col border-l shadow-md-left sm:min-w-72 ${navigationContext.navigation ? 'translate-x-0' : 'translate-x-full'}`}
         >
           <div className="anim text-secondary-4 flex w-full flex-row justify-between gap-2 p-4 pb-0 text-3xl md:pt-2">
-            <div className="spec-select flex w-full min-w-0 flex-1 font-eco text-2xl font-bold">
+            <div className="spec-select flex w-full min-w-0 flex-1 font-eco text-3xl font-bold">
               {specContext && (
                 <Select
                   selected={getSelected}

--- a/src/components/shared/core/guide/navigation/SelectSpecItem.tsx
+++ b/src/components/shared/core/guide/navigation/SelectSpecItem.tsx
@@ -1,6 +1,5 @@
 import { Option } from '@material-tailwind/react'
 import icons from '../../data/icons.json'
-import specs from '../../data/specs.json'
 import { useNavigate } from 'react-router-dom'
 import { useNavigationContext } from '../GuideContext'
 import { navigateToSpec } from '../../utilities/utils'
@@ -18,10 +17,6 @@ function SelectSpecItem({ job, spec }: Readonly<Props>) {
     icons[job as keyof typeof icons][
       spec as keyof (typeof icons)[keyof typeof icons]
     ]
-  const name: string =
-    specs[job as keyof typeof icons][
-      spec as keyof (typeof icons)[keyof typeof icons]
-    ]
   return (
     <Option
       value={job_spec}
@@ -30,11 +25,11 @@ function SelectSpecItem({ job, spec }: Readonly<Props>) {
       className="anim bg-accent-3 hover:bg-accent-4 border-accent-1 line-clamp-1 flex flex-none flex-row items-center gap-1 rounded-md border-2 px-2 py-1"
     >
       <img
-        className="h-6 w-6 rounded-sm border border-zinc-900"
+        className="h-7 w-7 rounded-sm border border-zinc-900"
         src={icon}
         alt={job_spec}
       />
-      <div className="font-bold text-zinc-900">{name}</div>
+      <div className="font-bold capitalize text-zinc-900">{spec}</div>
     </Option>
   )
 }

--- a/src/components/shared/core/home/SpecItem.tsx
+++ b/src/components/shared/core/home/SpecItem.tsx
@@ -26,14 +26,18 @@ function SpecItem({ job, spec }: Readonly<Props>) {
       value={job_spec}
       spec-theme={job}
       onClick={() => navigateToSpec(navigate, job_spec, navigationContext)}
-      className="anim bg-accent-3 border-accent-1 line-clamp-1 flex flex-none flex-row items-center gap-1 rounded-md border-2 px-2 py-1 hover:scale-110 sm:px-4 sm:py-2"
+      className="anim bg-accent-3 text-size-5 sm:text-size-2 border-accent-1 line-clamp-1 flex flex-none flex-row items-center gap-1 rounded-md border-2 px-2 py-1 sm:px-4 sm:py-2 sm:hover:scale-110"
     >
       <img
-        className="h-6 w-6 rounded-sm border border-zinc-900"
+        className="h-8 w-8 rounded-sm border border-zinc-900 sm:h-6 sm:w-6"
         src={icon}
         alt={job_spec}
       />
-      <div className="font-bold text-zinc-900">{name}</div>
+      <div className="hidden font-bold text-zinc-900 lg:block">{name}</div>
+      <div className="flex-1 font-bold capitalize text-zinc-900 lg:hidden">
+        {spec}
+      </div>
+      <div className="h-8 w-8"></div>
     </button>
   )
 }

--- a/src/components/shared/core/home/Specs.tsx
+++ b/src/components/shared/core/home/Specs.tsx
@@ -6,11 +6,11 @@ function Specs() {
   return (
     <div className="min-h-0 w-full flex-1">
       <CustomScroll heightRelativeToParent="100%">
-        <div className="text-size-2 flex w-full flex-col items-center gap-3 p-4 sm:grid sm:grid-cols-2 lg:flex">
+        <div className="text-size-2 flex w-full flex-col items-center gap-3 p-4">
           {Object.keys(specs).map((job) => (
             <div
               key={'home-specs-' + job}
-              className="flex w-full flex-col gap-1 sm:w-auto lg:flex-row"
+              className="flex w-full flex-col justify-center gap-1 sm:flex-row"
             >
               {Object.keys(specs[job as keyof typeof specs]).map((spec) => (
                 <SpecItem


### PR DESCRIPTION
### Modifications : 
- Only show spec name in guide's navigation menu
- Only show spec name for mobile in home
- Better positioning for home specs on mobile
- Font size changed to match positioning